### PR TITLE
pc - make system info controller available even when not logged in

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/SystemInfoController.java
@@ -20,7 +20,6 @@ public class SystemInfoController extends ApiController {
     private SystemInfoService systemInfoService;
 
     @ApiOperation(value = "Get global information about the application")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public SystemInfo getSystemInfo() {
         return systemInfoService.getSystemInfo();

--- a/src/test/java/edu/ucsb/cs156/example/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/SystemInfoControllerTests.java
@@ -27,19 +27,6 @@ public class SystemInfoControllerTests extends ControllerTestCase {
   @MockBean
   SystemInfoService mockSystemInfoService;
 
-  @Test
-  public void systemInfo__logged_out() throws Exception {
-    mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void systemInfo__user_logged_in() throws Exception {
-    mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().is(403));
-  }
-
   @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
   public void systemInfo__admin_logged_in() throws Exception {


### PR DESCRIPTION
# Overview

In this PR we fix the permissions for the systemInfo controller so that it doesn't require admin, or even being logged it at all.

That avoids this error in the front end:

<img width="691" alt="image" src="https://user-images.githubusercontent.com/1119017/163628819-6e5fc215-9628-4378-a104-05619a65aaf3.png">

