### PR TITLE
changed toast messages on useBackend to display error response message

### DIFF
--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -32,9 +32,12 @@ export function useBackend(queryKey, axiosParameters, initialData) {
             const response = await axios(axiosParameters);
             return response.data;
         } catch (e) {
-            const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
-            toast(errorMessage);
-            console.error(errorMessage, e);
+            if(e.response?.data){
+                toast.error(e.response.data.message);
+            }else{
+                const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
+                toast.error(errorMessage);
+            }
             throw e;
         }
     }, {
@@ -42,31 +45,21 @@ export function useBackend(queryKey, axiosParameters, initialData) {
     });
 }
 
-// const wrappedParams = async (params) =>
-//   await ( await axios(params)).data;
-
-
-const reportAxiosError = (error) => {
-    console.error("Axios Error:", error);
-    toast(`Axios Error: ${error}`);
-    return null;
-};
-
 const wrappedParams = async (params) => {
-    try {
-        return await (await axios(params)).data;
-    } catch (rejectedValue) {
-        reportAxiosError(rejectedValue);
-        throw rejectedValue;
-    }
+    return await (await axios(params)).data;
 };
 
 export function useBackendMutation(objectToAxiosParams, useMutationParams, queryKey=null) {
     const queryClient = useQueryClient();
 
     return useMutation((object) => wrappedParams(objectToAxiosParams(object)), {
-        onError: (data) => {
-            toast(`${data}`)
+        onError: (error) => {
+            if(error.response.data){
+                toast.error(error.response.data.message);
+            }else{
+                const errorMessage = `Error communicating with backend via ${error.response.config.method} on ${error.response.config.url}`;
+                toast.error(errorMessage);
+            }
         },
         // Stryker disable all: Not sure how to set up the complex behavior needed to test this
         onSettled: () => {

--- a/frontend/src/tests/pages/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/AdminUsersPage.test.js
@@ -5,10 +5,12 @@ import AdminUsersPage from "main/pages/AdminUsersPage";
 import usersFixtures from "fixtures/usersFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import mockConsole from "jest-mock-console";
+import { toast } from "react-toastify";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.spyOn(toast, 'error').mockImplementation();
 
 describe("AdminUsersPage tests", () => {
 
@@ -46,8 +48,6 @@ describe("AdminUsersPage tests", () => {
         const queryClient = new QueryClient();
         axiosMock.onGet("/api/admin/users").timeout();
 
-        const restoreConsole = mockConsole();
-
         const { queryByTestId } = render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -58,14 +58,12 @@ describe("AdminUsersPage tests", () => {
 
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
 
-        const errorMessage = console.error.mock.calls[0][0];
-        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");
-        restoreConsole();
+        await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
+        expect(mockToast).toHaveBeenCalledWith("Error communicating with backend via GET on /api/admin/users");
 
         expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
 
     });
-
 
 });
 

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "react-query";
 import { renderHook, act } from '@testing-library/react-hooks'
-import mockConsole from "jest-mock-console";
+import { toast } from "react-toastify";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
@@ -8,23 +8,12 @@ import { useBackend, useBackendMutation } from "main/utils/useBackend";
 
 
 jest.mock('react-router-dom');
-
-const mockToast = jest.fn();
-jest.mock('react-toastify', () => {
-    const originalModule = jest.requireActual('react-toastify');
-    return {
-        __esModule: true,
-        ...originalModule,
-        toast: (x) => mockToast(x)
-    };
-});
-
+const mockToast = jest.spyOn(toast, 'error').mockImplementation();
 
 describe("utils/useBackend tests", () => {
     describe("utils/useBackend useBackend tests", () => {
 
         test("test useBackend handles 404 error correctly", async () => {
-
             // See: https://react-query.tanstack.com/guides/testing#turn-off-retries
             const queryClient = new QueryClient({
                 defaultOptions: {
@@ -42,9 +31,7 @@ describe("utils/useBackend tests", () => {
 
             var axiosMock = new AxiosMockAdapter(axios);
 
-            axiosMock.onGet("/api/admin/users").reply(404, {});
-
-            const restoreConsole = mockConsole();
+            axiosMock.onGet("/api/admin/users").reply(404, {message:"Error: Request failed with status code 404"});
 
             const { result, waitFor } = renderHook(() => useBackend(
                 ["/api/admin/users"],
@@ -55,14 +42,12 @@ describe("utils/useBackend tests", () => {
             await waitFor(() => result.current.isError);
 
             expect(result.current.data).toEqual(["initialData"]);
-            await waitFor(() => expect(console.error).toHaveBeenCalled());
-            const errorMessage = console.error.mock.calls[0][0];
-            expect(errorMessage).toMatch("Error communicating with backend via GET on /api/admin/users");
-            restoreConsole();
 
+            await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
+            expect(mockToast).toHaveBeenCalledWith("Error: Request failed with status code 404");
         });
     });
-    describe("utils/useBackend useBackend tests", () => {
+    describe("utils/useBackend useBackendMutation tests", () => {
         test("test useBackendMutation handles success correctly", async () => {
 
             // See: https://react-query.tanstack.com/guides/testing#turn-off-retries
@@ -89,10 +74,6 @@ describe("utils/useBackend tests", () => {
                 localDateTime: '2022-02-02T12:00'
 
             });
-            // axiosMock.onPost("/api/ucsbdate/post").timeout();
-
-
-            // const restoreConsole = mockConsole();
 
             const objectToAxiosParams = (ucsbDate) => ({
                 url: "/api/ucsbdates/post",
@@ -123,17 +104,57 @@ describe("utils/useBackend tests", () => {
             await waitFor(() => expect(onSuccess).toHaveBeenCalled());
             expect(mockToast).toHaveBeenCalledWith("New ucsbDate Created - id: 17 name: Groundhog Day");
 
-            // const errorMessage = console.error.mock.calls[0][0];
-            // expect(errorMessage).toMatch("Fake");
-            // restoreConsole();
-
-
         });
-        test("test useBackendMutation handles error correctly", async () => {
+        test("test useBackendMutation handles error correctly with response message", async () => {
+            // See: https://react-query.tanstack.com/guides/testing#turn-off-retries
+            const queryClient = new QueryClient({
+                defaultOptions: {
+                    queries: {
+                        // ✅ turns retries off
+                        retry: false,
+                    },
+                },
+            })
+            const wrapper = ({ children }) => (
+                <QueryClientProvider client={queryClient}>
+                    {children}
+                </QueryClientProvider>
+            );
 
-            const restoreConsole = mockConsole();
+            const axiosMock = new AxiosMockAdapter(axios);
+            axiosMock.onPost("/api/ucsbdates/post").reply(404, {message:"Error: Request failed with status code 404"});
+
+            const objectToAxiosParams = (ucsbDate) => ({
+                url: "/api/ucsbdates/post",
+                method: "POST",
+                params: {
+                    quarterYYYYQ: ucsbDate.quarterYYYYQ,
+                    name: ucsbDate.name,
+                    localDateTime: ucsbDate.localDateTime
+                }
+            });
+
+            const onSuccess = jest.fn().mockImplementation((ucsbDate) => {
+                mockToast(`New ucsbDate Created - id: ${ucsbDate.id} name: ${ucsbDate.name}`);
+            });
 
 
+            const { result, waitFor } = renderHook(
+                () => useBackendMutation(objectToAxiosParams, { onSuccess }), { wrapper }
+            );
+
+            const mutation = result.current;
+
+            mutation.mutate({
+                quarterYYYYQ: '20221',
+                name: 'Groundhog Day',
+                localDateTime: '2022-02-02T12:00'
+            });
+
+            await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
+            expect(mockToast).toHaveBeenCalledWith("Error: Request failed with status code 404");
+        });
+        test("test useBackendMutation handles error correctly with no response message", async () => {
             // See: https://react-query.tanstack.com/guides/testing#turn-off-retries
             const queryClient = new QueryClient({
                 defaultOptions: {
@@ -177,22 +198,10 @@ describe("utils/useBackend tests", () => {
                 quarterYYYYQ: '20221',
                 name: 'Groundhog Day',
                 localDateTime: '2022-02-02T12:00'
-            }, {
-                onError: (e) => console.error("onError from mutation.mutate called!", String(e).substring(0, 199))
             });
 
-            await waitFor(() => expect(mockToast).toHaveBeenCalled());
-            expect(mockToast).toHaveBeenCalledTimes(2);
-            expect(mockToast).toHaveBeenCalledWith("Axios Error: Error: Request failed with status code 404");
-            expect(mockToast).toHaveBeenCalledWith("Error: Request failed with status code 404");
-
-            expect(console.error).toHaveBeenCalledTimes(2);
-            const errorMessage0 = console.error.mock.calls[0][0];
-            expect(errorMessage0).toMatch(/Axios Error:/);
-            const errorMessage1 = console.error.mock.calls[1][0];
-            expect(errorMessage1).toMatch(/onError from mutation.mutate/);
-
-            restoreConsole();
+            await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
+            expect(mockToast).toHaveBeenCalledWith("Error communicating with backend via post on /api/ucsbdates/post");
         });
     });
 });


### PR DESCRIPTION
# Overview

In this PR I edited the utilities/useBackend.js to make it so the toast display the error/exception message that was given instead of just `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`. If the error does not have a response then the toast will display  `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}` as a default. 
