### PR TITLE
Add controller tests for project cloning controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/jobs/Job.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/jobs/Job.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @Builder
 @Entity(name = "jobs")
 @EntityListeners(AuditingEntityListener.class)

--- a/src/test/java/edu/ucsb/cs156/example/ControllerTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/example/ControllerTestCase.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.example;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
@@ -30,6 +31,11 @@ public abstract class ControllerTestCase {
 
   @Autowired
   public ObjectMapper mapper;
+
+  @SneakyThrows
+  protected String asJsonString(Object obj) {
+    return mapper.writeValueAsString(obj);
+  }
 
   protected Map<String, Object> responseToJson(MvcResult result) throws UnsupportedEncodingException, JsonProcessingException {
     String responseString = result.getResponse().getContentAsString();

--- a/src/test/java/edu/ucsb/cs156/example/JobTestUtils.java
+++ b/src/test/java/edu/ucsb/cs156/example/JobTestUtils.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.example;
+
+import edu.ucsb.cs156.example.entities.jobs.Job;
+import edu.ucsb.cs156.example.repositories.jobs.JobsRepository;
+import edu.ucsb.cs156.example.services.jobs.JobContext;
+import edu.ucsb.cs156.example.services.jobs.JobContextConsumer;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Mockito.mock;
+
+public class JobTestUtils {
+  public static Answer<Job> runJobAndReturn(Job job) {
+    return runJobAndReturn(job, mock(JobsRepository.class));
+  }
+
+  public static Answer<Job> runJobAndReturn(Job job, JobsRepository jobsRepository) {
+    return invocation -> {
+      ((JobContextConsumer) invocation.getArgument(0)).accept(new JobContext(jobsRepository, job));
+      return job;
+    };
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ProjectCloningControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ProjectCloningControllerTests.java
@@ -1,0 +1,98 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.JobTestUtils;
+import edu.ucsb.cs156.example.entities.jobs.Job;
+import edu.ucsb.cs156.example.services.GithubProjectCloningService;
+import edu.ucsb.cs156.example.services.jobs.JobService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ProjectCloningController.class)
+@AutoConfigureDataJpa
+public class ProjectCloningControllerTests extends ControllerTestCase {
+  @MockBean
+  private JobService jobService;
+
+  @MockBean
+  private GithubProjectCloningService cloningService;
+
+  @Test
+  public void cloneBoard__fails_when_not_logged_in() throws Exception {
+    String content = asJsonString(Map.of(
+      "fromProjectId", "PRO_dummyid",
+      "toRepoId", "R_dummyid"
+    ));
+
+    mockMvc.perform(
+        post("/api/projectcloning/clone")
+          .with(csrf())
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(content)
+      )
+      .andExpect(status().isForbidden());
+
+    verifyNoInteractions(jobService);
+    verifyNoInteractions(cloningService);
+  }
+
+  @WithMockUser
+  @Test
+  public void cloneBoard__fails_when_not_admin() throws Exception {
+    String content = asJsonString(Map.of(
+      "fromProjectId", "PRO_dummyid",
+      "toRepoId", "R_dummyid"
+    ));
+
+    mockMvc.perform(
+        post("/api/projectcloning/clone")
+          .with(csrf())
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(content)
+      )
+      .andExpect(status().isForbidden());
+
+    verifyNoInteractions(jobService);
+    verifyNoInteractions(cloningService);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void cloneBoard__valid() throws Exception {
+    Job job = Job.builder().id(13).build();
+
+    when(jobService.runAsJob(any()))
+      .thenAnswer(JobTestUtils.runJobAndReturn(job));
+
+    String content = asJsonString(Map.of(
+      "fromProjectId", "PRO_dummyid",
+      "toRepoId", "R_dummyid"
+    ));
+
+    mockMvc.perform(
+      post("/api/projectcloning/clone")
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(content)
+      )
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$").value(job));
+
+    verify(jobService).runAsJob(any());
+    verifyNoMoreInteractions(jobService);
+
+    verify(cloningService).cloneProject("PRO_dummyid", "R_dummyid");
+    verifyNoMoreInteractions(cloningService);
+  }
+}


### PR DESCRIPTION
This PR implements controller tests for the project cloning controller, as well as adds some utilities for testing code that uses the jobs service.

`JobTestUtils#runJobAndReturn` is a utility method to be used with Mockito's `thenAnswer`. This utility allows you to mock `JobService#runAsJob` with an implementation of the method that invokes the job and returns a given job state object. The method has two overloads, with one accepting an additional JobsRepository parameter in case additional control over the JobsRepository mock is required. Otherwise, a fresh JobsRepository mock is instantiated and passed through the job context. 